### PR TITLE
Fix binding of event listener to input element

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -52,6 +52,8 @@ export default class bulmaSlider extends EventEmitter {
   init() {
     this._id = 'bulmaSlider' + (new Date()).getTime() + Math.floor(Math.random() * Math.floor(9999));
     this.output = this._findOutputForSlider();
+    
+    this._bindEvents();
 
     if (this.output) {
       if (this.element.classList.contains('has-output-tooltip')) {
@@ -67,13 +69,15 @@ export default class bulmaSlider extends EventEmitter {
   }
 
   _findOutputForSlider() {
+    const result = null;
     const outputs = document.getElementsByTagName('output');
-    [].forEach.call(outputs, output => {
+    [].some.call(outputs, output => {
       if (output.htmlFor == this.element.getAttribute('id')) {
-        return output;
+        result = output;
+        return true;
       }
     });
-    return null;
+    return result;
   }
 
   _getSliderOutputPosition() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -69,7 +69,7 @@ export default class bulmaSlider extends EventEmitter {
   }
 
   _findOutputForSlider() {
-    const result = null;
+    let result = null;
     const outputs = document.getElementsByTagName('output');
     [].some.call(outputs, output => {
       if (output.htmlFor == this.element.getAttribute('id')) {


### PR DESCRIPTION
1. `this._bindEvents()` was missing in the `init()` function.

2. It's not possible to return an object from within a `forEach` loop via the return statement. Instead assign the output to return to a variable in the enclosing scope and return this at the end.