### PR TITLE
Disable Touchscreen Pan-X / Pan-Y

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -50,7 +50,7 @@ input[type=range]
 		appearance: none
 		margin: 1rem 0
 		background: transparent
-		touch-action: none;
+		touch-action: none
 
 		&.is-fullwidth
 			display: block

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -50,6 +50,7 @@ input[type=range]
 		appearance: none
 		margin: 1rem 0
 		background: transparent
+		touch-action: none;
 
 		&.is-fullwidth
 			display: block


### PR DESCRIPTION
Dragging the slider on touchscreen devices makes the browser think that the user is trying to pan/scroll the page by holding on to it. Touch events have been disabled for the slider. So that only the thumb moves rather than making it move along with the whole webpage on touchscreen devices.