### PR TITLE
Use `math.div` instead of slash div

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -13,7 +13,7 @@ $slider-output-background: $grey-dark !default
 $slider-output-radius: $radius !default
 
 =slider-size($size)
-	$track-height: $size / $slider-thumb-to-track-ratio
+	$track-height: math.div($size, $slider-thumb-to-track-ratio)
 	$thumb-size: $size
 
 	&:not([orient="vertical"])
@@ -48,12 +48,12 @@ $slider-output-radius: $radius !default
 		margin-top: 0
 
 	&::-webkit-slider-thumb
-		margin-top: -($thumb-size / 4)
+		margin-top: -math.div($thumb-size, 4)
 
 	&[orient="vertical"]
 		&::-webkit-slider-thumb
 			margin-top: auto
-			margin-left: -($thumb-size / 4)
+			margin-left: -math.div($thumb-size, 4)
 
 input[type="range"]
 	&.slider


### PR DESCRIPTION
Fix the use of / for division. Error log below:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
```